### PR TITLE
Add fix to stringify decimals

### DIFF
--- a/postgis2geojson.py
+++ b/postgis2geojson.py
@@ -1,5 +1,6 @@
 import argparse
 import datetime
+import decimal
 import json
 import subprocess
 
@@ -61,6 +62,13 @@ parser.add_argument("--pretty", dest="pretty",
 
 arguments = parser.parse_args()
 
+# Fix to stringify decimals
+# http://stackoverflow.com/questions/16957275/python-to-json-serialization-fails-on-decimal
+def decimal_default(obj):
+    if isinstance(obj, decimal.Decimal):
+        return float(obj)
+    raise TypeError
+    
 def getData():
     # Connect to the database
     try:
@@ -130,7 +138,7 @@ def getData():
         feature_collection['features'].append(feature)
 
     indent = 2 if arguments.pretty else None
-    jsonified = json.dumps(feature_collection, indent=indent)
+    jsonified = json.dumps(feature_collection, indent=indent, default=decimal_default)
 
     # Write it to a file
     with open(arguments.file + '.geojson', 'w') as outfile:

--- a/postgis2geojson.py
+++ b/postgis2geojson.py
@@ -62,9 +62,9 @@ parser.add_argument("--pretty", dest="pretty",
 
 arguments = parser.parse_args()
 
-# Fix to stringify decimals
+# Fix to float decimals
 # http://stackoverflow.com/questions/16957275/python-to-json-serialization-fails-on-decimal
-def decimal_default(obj):
+def check_for_decimals(obj):
     if isinstance(obj, decimal.Decimal):
         return float(obj)
     raise TypeError
@@ -138,7 +138,7 @@ def getData():
         feature_collection['features'].append(feature)
 
     indent = 2 if arguments.pretty else None
-    jsonified = json.dumps(feature_collection, indent=indent, default=decimal_default)
+    jsonified = json.dumps(feature_collection, indent=indent, default=check_for_decimals)
 
     # Write it to a file
     with open(arguments.file + '.geojson', 'w') as outfile:


### PR DESCRIPTION
This is to fix the following error I was getting on trying to serialize decimals
```
  File "/usr/lib/python2.7/json/encoder.py", line 184, in default
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: Decimal('3.52211579667') is not JSON serializable
```

I have modified the code using this fix: http://stackoverflow.com/questions/16957275/python-to-json-serialization-fails-on-decimal