### PR TITLE
Replace topojson with geo2topo

### DIFF
--- a/postgis2geojson.py
+++ b/postgis2geojson.py
@@ -151,7 +151,7 @@ def getData():
         print "Done!"
 
 def topojson():
-    command = "topojson -o " + arguments.file + ".topojson -p -- " + arguments.file + ".geojson" 
+    command = "geo2topo -o " + arguments.file + ".topojson -p -- " + arguments.file + ".geojson" 
     subprocess.call(command, shell=True)
 
 # Start the process


### PR DESCRIPTION
`geo2topo` should now be used rather than `topojson`. Executing as is fails. 
Ref: https://stackoverflow.com/a/40730951/218766